### PR TITLE
ci(deps): track bench/ dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+  - package-ecosystem: "npm"
+    directory: "/bench"
+    schedule:
+      interval: "monthly"
+    groups:
+      bench-dependencies:
+        patterns: ["*"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

Adds a third `.github/dependabot.yml` entry for `bench/`'s own `package.json` (introduced in #214). Dependabot's npm entries are per-directory and don't recurse, so the root entry never covered `bench/` — confirmed the root's `directory: "/"` only scans the repo root, no overlap with the new `/bench` entry.

- `interval: monthly`, not `weekly` like the root entry — `bench/`'s dependencies are comparison libraries (chroma-js, tinycolor2, etc.) that only affect benchmark numbers, not the published package, tests, or CI. Weekly bumps here would be pure noise.
- Grouped by `patterns: ["*"]`, not `dependency-type: "development"` — verified `bench/package.json` lists everything under `"dependencies"`, not `"devDependencies"`, so the `dependency-type` filter used for the root group wouldn't match anything there.

## Verification
- YAML parses correctly; root `npm` (weekly) and `github-actions` (weekly) entries unchanged
- `npm ci`, `npm run lint` (0 errors, same 5 pre-existing warnings), `npm run build`, `npm test` (148/148) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)