### PR TITLE
ci: bump compressed-size-action to v3, fix required build-script input

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -38,7 +38,8 @@ jobs:
         run: npm run build
 
       - name: Compressed size
-        uses: preactjs/compressed-size-action@v2
+        uses: preactjs/compressed-size-action@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: "./dist/*.{js,cjs}"
+          build-script: build

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -24,6 +24,9 @@ jobs:
   compressed-size:
     runs-on: ubuntu-latest
     needs: [shared-ci]
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -42,4 +42,4 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: "./dist/*.{js,cjs}"
-          build-script: build
+          build-script: npm run build


### PR DESCRIPTION
## Summary

`preactjs/compressed-size-action` v3 made `build-script` a required input with no default (v2 defaulted to `"build"`), which is why dependabot's v2->v3 bump PR was failing with `Input required and not supplied: build-script` here and across the other kurkle repos using this action.

1. **Version bump + required input**: `v2` -> `v3`, added `build-script`. Went through two iterations verified against real CI runs:
   - First tried `build-script: build` (the bare npm script name, matching v2-era docs) - failed: `Unable to locate executable file: build`. v3 actually runs this value as a literal shell command, not an npm-script lookup (confirmed against the v3 README's own usage examples, which pass `"npm run build"`).
   - Fixed to `build-script: npm run build` - the build itself then succeeded for both the PR ref and base ref.
2. **Kept the job's own `Install dependencies`/`Build` steps as-is.** Did not remove them - this repo's build is more involved than the others using this action (packed.ts placeholder swap, tsc declaration generation, three esbuild bundle formats), and the coordinated fix across all affected repos is intentionally scoped to just the version bump + build-script correction, not a step-reduction optimization.
3. **Found and fixed a second, previously-silent bug while verifying the report**: the action computed a correct size report (`Total Size: 15 kB`, `Size Change: 0 B`) but failed to post it - `Error creating comment: Resource not accessible by integration`, then the PR-review fallback also failed. `pr-ci.yml`'s workflow-level `permissions: contents: read` never granted `pull-requests: write`, so this had nothing to do with the v2/v3 bump - it's been silently producing nothing since the compressed-size job was added in #215. Same gap exists in the reference repos. Fixed by giving the `compressed-size` job its own job-level `permissions` block (which replaces rather than merges with the workflow-level one, so `contents: read` is repeated there); left the workflow-level permissions untouched since no other job needs write access.

## Verification
- `npm run lint`/`npm test` pass locally
- Real CI run on this PR: `compressed-size` check passes, and the bot comment now actually appears on the PR with the correct size table (verified via the GitHub API, not just the green checkmark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)