### PR TITLE
ci: pass SONAR_TOKEN explicitly, scan workflow files with Sonar

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -20,7 +20,8 @@ jobs:
       browser-tests: false
       test-command: npm run test:coverage
       coverage-paths: coverage/lcov.info
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -19,7 +19,8 @@ jobs:
       browser-tests: false
       test-command: npm run test:coverage
       coverage-paths: coverage/lcov.info
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   compressed-size:
     runs-on: ubuntu-latest

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,8 +5,15 @@ sonar.organization=kurkle
 sonar.projectName=color
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=src/
+sonar.sources=src/,.github/workflows
 sonar.tests=src/,test/
 sonar.test.inclusions=**/*.test.ts,**/*.test.js
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# The floating v1 tag is deliberate: it is how a fix in kurkle/configs reaches
+# every repository without a pull request in each one. Pinning a commit SHA
+# would defeat that mechanism.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/*.yml


### PR DESCRIPTION
## Summary

`kurkle/configs` v1.3.0 (which `v1` now points to) declares `SONAR_TOKEN` as a named secret on the reusable `shared-ci.yml` workflow instead of relying on `secrets: inherit`. Updated both `pr-ci.yml` and `main-ci.yml` to pass it explicitly; `GITHUB_TOKEN` needs no passthrough since it's always available.

`sonar-project.properties`:
- Added `.github/workflows` to `sonar.sources` so the workflow files are actually scanned (this also brings `bench.yml` into scope, since it's in the same directory).
- Added an ignore rule for `githubactions:S7637` scoped to `.github/workflows/*.yml`, documenting that the floating `v1` tag on the `shared-ci.yml` reference is intentional.

## Verification (and an honest limit on what I could verify from a PR)

- Sonar passes on this PR, and I confirmed via the SonarCloud API (not just the checkmark) that `.github/workflows/main-ci.yml` and `.github/workflows/pr-ci.yml` now show up as analyzed components (`api/components/tree`) - before this change, `.github/workflows` wasn't in `sonar.sources` at all, so these files weren't visible to Sonar in any form. Zero new issues were reported on this PR's own diff (`api/issues/search?...&pullRequest=225` returns `total: 0`).
- **What I could not verify from here**: SonarCloud's pull-request analysis only evaluates *changed* lines for "new code" issues. The `uses: kurkle/configs/...@v1` line (where S7637 would apply) wasn't itself touched by my diff, and `bench.yml` has no diff at all in this PR - so neither can produce a "new issue" in a PR-scoped scan regardless of the ignore rule's correctness. Whether the ignore rule actually suppresses S7637 there, and whether `bench.yml` produces any new findings once it's in scope, will only be observable after this merges to `main` and the next full-branch scan runs. Flagging this rather than claiming a confirmation I structurally couldn't get without merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)