### PR TITLE
ci(deps): ignore TypeScript major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+    ignore:
+      # typedoc requires typescript 5.x or 6.x, so TS 7 fails npm ci with
+      # ERESOLVE and stalls the whole dev-dependencies group.
+      # Remove this once typedoc supports TypeScript 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm"
     directory: "/bench"
     schedule:


### PR DESCRIPTION
## Summary

Dependabot's `dev-dependencies` group (#221) has been failing at `npm clean-install` with `ERESOLVE`. Root cause: `typedoc@0.28.20` (its latest release) declares a peer dependency on `typescript` `5.x` or `6.x` only:

\`\`\`
$ npm view typedoc peerDependencies
{ typescript: '5.0.x || 5.1.x || ... || 5.9.x || 6.0.x' }
\`\`\`

TypeScript 7 (currently latest on npm) fails that peer requirement and stalls the whole group. No upstream fix exists - typedoc hasn't released TS 7 support yet.

Added an `ignore` rule to the root `npm` entry only, matching the format already used in chartjs-chart-matrix/chartjs-chart-sankey/chartjs-chart-treemap's dependabot.yml (fetched matrix's current version via the GitHub API rather than a possibly-stale local clone). Scoped to the root entry - `bench/` doesn't use TypeScript, so its entry is untouched. The comment names `typedoc` as the actual reason, not `@astrojs/check` (which is why the equivalent rule exists in the Astro-based repos) - copying that comment verbatim would have been factually wrong here.

## Verification
- `npm run lint` - 0 errors, same 5 pre-existing warnings
- YAML validated for syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)