### PR TITLE
ci: pass --ignore-scripts to every npm install in workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,7 +16,7 @@ jobs:
           cache: npm
       - name: Build
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run lint
           npm run build
       - name: Test
@@ -24,7 +24,7 @@ jobs:
       - name: Reset
         run: git reset --hard
       - name: Install benchmark dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: bench
       - name: Benchmark hex parsing
         run: node --expose-gc bench/hexbench.js | tee output.txt

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -44,7 +44,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install --ignore-scripts
 
       - name: Build
         run: npm run build
@@ -69,7 +69,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install --ignore-scripts
 
       - name: Build
         run: npm run build

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -36,7 +36,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install --ignore-scripts
 
       - name: Build
         run: npm run build
@@ -47,3 +47,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: "./dist/*.{js,cjs}"
           build-script: npm run build
+          install-script: npm ci --ignore-scripts


### PR DESCRIPTION
## Summary

SonarCloud (`githubactions:S6505`) flagged `bench.yml`'s two `npm ci` calls (lines 19, 27) for allowing lifecycle scripts to run during install - a real, current npm malware-distribution vector, not just a lint nit. Extended the fix to every install across all workflow files, since the same reasoning applies uniformly rather than just where Sonar happened to flag it:

- `bench.yml`: both `npm ci` calls (root build/test, `bench/` dependencies) - these are the two the finding was actually on
- `main-ci.yml`: `release` job and `docs` job installs
- `pr-ci.yml`: `compressed-size` job's own install, plus a new `install-script: npm ci --ignore-scripts` input, since the action builds both the PR ref and base ref with its own internal install
- `kurkle/configs`' shared `shared-ci.yml` sets its own default separately and isn't touched here

Note: `main-ci.yml`/`pr-ci.yml` use `npm clean-install` (the alias), which SonarCloud apparently doesn't pattern-match the same way as `npm ci` - confirmed via the API that on `main`, all 2 existing S6505 findings are on `bench.yml` only, none on the other two files. So those two files' changes are a real security hardening, just not something the scanner was flagging in the first place - not claiming a Sonar improvement there that isn't measurable.

## Why this doesn't break the build

The concern going in: `color`'s build is more involved than most (esbuild + `scripts/pack.js` + a `packed.ts` placeholder swap), and `esbuild` itself has a `postinstall` script. Checked the whole dependency tree - `esbuild` is the *only* package with an install script. Confirmed empirically that `--ignore-scripts` doesn't affect it: the platform binary comes from the `@esbuild/<platform>` optional dependency via normal npm resolution, not from the postinstall script - `node_modules/@esbuild/darwin-arm64/bin/esbuild` exists and works fine after a `--ignore-scripts` install, with a fresh timestamp confirming it wasn't cached from a prior run.

## Verification (all with a `--ignore-scripts` install)
- `npm run lint`, `npm run typecheck`, `npm test` (148/148) - all pass
- `npm run build` succeeds (packed.ts placeholder swap, tsc declarations, all three esbuild bundle formats)
- `npm run build && npm run docs` produces both the typedoc site and `docs/stats.html` together - the exact thing #215 fixed from going stale when build/docs got split into separate jobs, re-verified here since it's the same install path
- `bench/`'s own install plus `node --expose-gc bench/hexbench.js` and `bench/compare.js`, run from the repo root exactly as `bench.yml` invokes them
- Real CI run on this PR: `compressed-size` posted an actual report (`Total Size: 15 kB`), confirming `install-script` worked for both refs the action built internally

## SonarCloud check (same PR-analysis limit as #225)
Confirmed via the API that `main` currently has exactly 2 open `githubactions:S6505` findings, both on the exact lines this PR changes (`bench.yml:19`, `bench.yml:27`). This PR's own diff shows 0 new issues on those touched lines, which is a good sign - but whether they show as resolved is only fully confirmable after this merges and the next full `main` scan runs, same PR-vs-full-scan limitation as the S7637 ignore rule in #225.

🤖 Generated with [Claude Code](https://claude.com/claude-code)