### PR TITLE
test: pin the Chart.js runtime contract for Color

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "build": "node scripts/build.js",
     "lint": "biome check",
     "format": "biome check --write",
-    "test": "vitest run",
-    "test:coverage": "vitest run --coverage",
+    "test": "vitest run && npm run test:chartjs",
+    "test:coverage": "vitest run --coverage && npm run test:chartjs",
     "typecheck": "tsc --noEmit",
+    "test:chartjs": "npm --prefix test/chartjs-compat ci --ignore-scripts && npm --prefix test/chartjs-compat run check",
     "docs": "typedoc && touch docs/.nojekyll && mv -f docs/tmp/* docs/ && rm -rd docs/tmp",
     "prepare": "git config core.hooksPath .githooks || true"
   },

--- a/test/chartjs-compat/package-lock.json
+++ b/test/chartjs-compat/package-lock.json
@@ -1,0 +1,66 @@
+{
+  "name": "chartjs-compat-fixture",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "chartjs-compat-fixture",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@kurkle/color": "file:../..",
+        "chart.js": "4.5.1",
+        "typescript": "^6.0.3"
+      }
+    },
+    "../..": {
+      "name": "@kurkle/color",
+      "version": "0.0.0-development",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@biomejs/biome": "^2.5.12",
+        "@kurkle/configs": "^1.1.1",
+        "@vitest/coverage-v8": "^5.0.0",
+        "color-name": "^2.0.0",
+        "esbuild": "^0.28.2",
+        "esbuild-visualizer": "^0.7.0",
+        "semantic-release": "^25.0.9",
+        "typedoc": "^0.28.5",
+        "typescript": "^6.0.3",
+        "vitest": "^5.0.0"
+      }
+    },
+    "node_modules/@kurkle/color": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/test/chartjs-compat/package.json
+++ b/test/chartjs-compat/package.json
@@ -1,0 +1,19 @@
+{
+  "devDependencies": {
+    "@kurkle/color": "file:../..",
+    "chart.js": "4.5.1",
+    "typescript": "^6.0.3"
+  },
+  "name": "chartjs-compat-fixture",
+  "overrides": {
+    "chart.js": {
+      "@kurkle/color": "file:../../../.."
+    }
+  },
+  "private": true,
+  "scripts": {
+    "check": "tsc --noEmit && node --test runtime.test.mjs"
+  },
+  "type": "module",
+  "version": "0.0.0"
+}

--- a/test/chartjs-compat/runtime.test.mjs
+++ b/test/chartjs-compat/runtime.test.mjs
@@ -1,0 +1,53 @@
+import { color, getHoverColor } from 'chart.js/helpers'
+
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+// Chart.js does not import this package's `Color` class directly in
+// application code. Instead, Chart.js itself (and any plugin built against
+// its public `chart.js/helpers` API, e.g. chartjs-plugin-autocolors) calls
+// two small helpers, `color()` and `getHoverColor()`, that wrap
+// `@kurkle/color`:
+//
+//   function color(value) {
+//     return isPatternOrGradient(value) ? value : new Color(value)
+//   }
+//   function getHoverColor(value) {
+//     return isPatternOrGradient(value) ? value : new Color(value).saturate(0.5).darken(0.1).hexString()
+//   }
+//
+// That is the runtime contract this package must not break: a named `Color`
+// export, `new Color(input)`, chainable `saturate()`/`darken()`, and
+// `hexString()` - including its `undefined` return for invalid input.
+//
+// This fixture's own `package.json` `overrides` field forces chart.js's own
+// `@kurkle/color` dependency (chart.js declares ^0.3.0) to resolve to this
+// repo instead, so importing `chart.js/helpers` below runs Chart.js's real,
+// installed code against this repo's own built `dist/color.esm.js`
+// artifact - the same artifact real consumers get from npm - through the
+// same `exports` entry point a real consumer would use. That's what makes
+// this an integration test rather than a hand-rolled re-creation of the
+// pattern: it fails if this package's `exports` map stops resolving
+// correctly for Chart.js, not just if `Color`'s behavior changes.
+
+test('color() wraps a valid CSS color string in a Color instance', () => {
+  assert.equal(color('#ff0000').hexString(), '#F00')
+})
+
+test('color() wraps an invalid CSS color string in an invalid Color instance', () => {
+  assert.equal(color('not-a-color').hexString(), undefined)
+})
+
+test('getHoverColor works through chart.js against the local build', () => {
+  // Values measured directly against this repo's built dist, running
+  // through chart.js's actual getHoverColor() implementation.
+  assert.equal(getHoverColor('#ff0000'), '#E60000')
+  assert.equal(getHoverColor('rgb(0,128,255)'), '#0073E6')
+  assert.equal(getHoverColor('red'), '#E60000')
+  assert.equal(getHoverColor('#abc'), '#88A8C9')
+  assert.equal(getHoverColor('rgba(1,2,3,0.5)'), '#0102047F')
+})
+
+test('getHoverColor returns undefined for an invalid CSS color string', () => {
+  assert.equal(getHoverColor('not-a-color'), undefined)
+})

--- a/test/chartjs-compat/tsconfig.json
+++ b/test/chartjs-compat/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["*.ts"]
+}

--- a/test/chartjs-compat/usage.ts
+++ b/test/chartjs-compat/usage.ts
@@ -1,0 +1,52 @@
+import type { ChartOptions } from 'chart.js'
+
+import { Color } from '@kurkle/color'
+
+// Chart.js's own getHoverColor, verbatim (dist/chunks/helpers.dataset.js),
+// declares a `string` return type for the wrapped call below:
+//
+//   function getHoverColor(value) {
+//     return isPatternOrGradient(value) ? value : new Color(value).saturate(0.5).darken(0.1).hexString();
+//   }
+//
+// @kurkle/color >= 0.5 correctly types hexString() as `string | undefined`
+// (0.4's `string` return type was a lie: it also returned `undefined` for
+// invalid input at runtime, only the type didn't say so). That means
+// chart.js's own helpers source, typed verbatim against this package's
+// current types, no longer type-checks. This is a real, currently-open gap
+// in chart.js's own types, not a mistake in this package - it doesn't get
+// silently worked around here.
+//
+// @ts-expect-error @kurkle/color >= 0.5 returns string | undefined here;
+// chart.js's own type declarations have not been updated to match, and
+// need a fix on chart.js's side when it next bumps its @kurkle/color range.
+const chartjsVerbatim: string = new Color('#f00').saturate(0.5).darken(0.1).hexString()
+
+// The pattern a consumer must actually use against @kurkle/color >= 0.5.
+const corrected: string = new Color('#f00').saturate(0.5).darken(0.1).hexString() ?? '#f00'
+
+// A corrected value is exactly what Chart.js expects wherever it accepts a
+// color.
+const opts: ChartOptions<'line'> = {
+  elements: { line: { borderColor: corrected } },
+}
+
+// Rest of the public surface Chart.js and its plugins (e.g.
+// chartjs-plugin-autocolors) rely on.
+const valid: boolean = new Color('#f00').valid
+const rgb = new Color('#f00').rgb
+const rgbString: string | undefined = new Color('#f00').rgbString()
+const hslString: string | undefined = new Color('#f00').hslString()
+const mixed: Color = new Color('#f00').mix(new Color('#00f'), 0.5)
+const cloned: Color = new Color('#f00').clone()
+const alphaed: Color = new Color('#f00').alpha(0.5)
+
+void chartjsVerbatim
+void opts
+void valid
+void rgb
+void rgbString
+void hslString
+void mixed
+void cloned
+void alphaed


### PR DESCRIPTION
## Why

`@kurkle/color` is built largely for Chart.js, but nothing in this repo verified that its runtime contract with Chart.js still holds. Version 0.5 broke the TypeScript types `chartjs-plugin-autocolors` relied on, and nothing caught it before a human did.

Chart.js's entire runtime contract with this package is two small helpers it exports from `chart.js/helpers` (used internally and by plugin authors):

```js
function color(value) {
  return isPatternOrGradient(value) ? value : new Color(value)
}
function getHoverColor(value) {
  return isPatternOrGradient(value) ? value : new Color(value).saturate(0.5).darken(0.1).hexString()
}
```

That is: a named `Color` export, `new Color(input)`, chainable `saturate()`/`darken()`, and `hexString()` — including its `undefined` return for invalid input.

## `test/chartjs-compat/` — a self-contained fixture

This check lives entirely in its own directory: its own `package.json`, its own `package-lock.json`, and its own `tsconfig.json`. **It installs its own dependencies and is not referenced from the published `package.json`, `package-lock.json`, or any CI workflow configuration.** If Chart.js ever stops depending on `@kurkle/color`, the whole check can be deleted by removing this one directory — nothing else in the repo needs to change.

It's wired in as a continuation of the existing test scripts, not a new CI step:

```json
"test": "vitest run && npm run test:chartjs",
"test:coverage": "vitest run --coverage && npm run test:chartjs",
"test:chartjs": "npm --prefix test/chartjs-compat ci --ignore-scripts && npm --prefix test/chartjs-compat run check"
```

Since shared CI already runs `npm run test:coverage`, this runs automatically wherever that already runs, with no `.github/workflows/*.yml` changes.

### Runtime test (`runtime.test.mjs`, via Node's built-in test runner — no vitest needed in the fixture)

Imports `color`/`getHoverColor` directly from `chart.js/helpers` and runs Chart.js's real, installed implementation against this package's own built `dist/color.esm.js` artifact, reached through the exact `exports` entry point a real consumer would use.

This replaces an earlier draft of this test (previously at the repo root) that read chart.js's helpers source with a regex and hand re-created the pattern wired to `../dist/color.esm.js` via a direct relative import, bypassing `exports` entirely. That could never have caught the regression class this test exists for: 0.5's `exports` map restructuring (0.4 had `"types": "./dist/color.d.ts"`; 0.5 split it into separate esm/cjs type entries).

**Confirmed directly:** with only the root `package.json`'s `exports.import` broken (`dist` completely untouched), this test fails with `ERR_MODULE_NOT_FOUND`; restoring it turns it green again.

The fixture's own `overrides` field (`{ "chart.js": { "@kurkle/color": "file:../../../.." } }`) makes chart.js's own `@kurkle/color` dependency (chart.js declares `^0.3.0`) resolve to this repo's build too, instead of a separate stale nested copy — so `chart.js/helpers` genuinely runs against this repo's code. Note the path differs from the plain devDependency above (`file:../..`): npm resolves a direct `file:` dependency relative to the package.json declaring it, but writes an `overrides` entry's resolved path as the override value taken literally relative to the overridden package's own location one level deeper, hence the extra `..`. Both were confirmed by installing from a clean state and checking the resulting symlink target.

### Type check (`usage.ts` + `tsconfig.json`, run via `tsc --noEmit`)

Imports `@kurkle/color` **by package name** (through `exports`, not a relative path) and exercises the public surface Chart.js and its plugins rely on (`hexString`, `rgbString`, `hslString`, `valid`, `rgb`, `mix`, `clone`, `alpha`).

This documents a real, currently-open type gap with `@ts-expect-error` rather than working around it: chart.js's own `getHoverColor`, typed verbatim, no longer type-checks against `@kurkle/color >= 0.5`, because `hexString()` correctly returns `string | undefined` (0.4's `string` return type was a lie — it also returned `undefined` for invalid input at runtime; only the type didn't say so). Any consumer of chart.js's own helper needs `?? fallback`; chart.js's own type declarations need a fix when it next bumps its `@kurkle/color` range.

**Confirmed:** narrowing `hexString()`'s return type back to `string` (dist untouched) turns the directive into `TS2578: Unused '@ts-expect-error' directive` — so a fix on either side is caught automatically instead of silently going stale. Renaming `hexString` produces `TS2339: Property 'hexString' does not exist on type 'Color'`. Removing the `@ts-expect-error` line reveals the real underlying `TS2322: Type 'string | undefined' is not assignable to type 'string'`.

**Confirmed the root `npm run typecheck` never touches this file:** the root `tsconfig.json` already excludes `test`, and planting a syntax error in `usage.ts` produces zero effect on the root typecheck — only the fixture's own `check` script sees it.

## Verification

- `npm ci` at the root succeeds (no `overrides`, no `chart.js` there — both live only in the fixture now).
- `npm --prefix test/chartjs-compat ci` succeeds against the fixture's own lockfile, generated from a clean `node_modules`.
- `npm test` at the root: **148 tests** (down from an earlier draft's 156 — the chart.js integration test moved out of vitest into the fixture's own `node --test` run; nothing was deleted). `npm run test:coverage`: 98.83% statements / 95.67% branches / 97.26% functions / 98.72% lines.
- `npm run test:chartjs`: `tsc --noEmit` clean, 4/4 `node --test` assertions pass.
- `npm run build`, `npm run lint`, `npm run typecheck`, `npm run docs` all clean.

## Note (out of scope)

Because the fixture's `overrides` now applies (it didn't in an earlier draft where `chart.js` lived at the root without an override), chart.js no longer gets its own separately-resolved nested `@kurkle/color@0.3.x` inside the fixture — it resolves to this repo's build via the hoisted symlink instead. That's expected and is what makes the runtime test meaningful.
