### PR TITLE
chore: run build in prepack so published banner has the real version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "typecheck": "tsc --noEmit",
     "test:chartjs": "npm --prefix test/chartjs-compat ci --ignore-scripts && npm --prefix test/chartjs-compat run check",
     "docs": "typedoc && touch docs/.nojekyll && mv -f docs/tmp/* docs/ && rm -rd docs/tmp",
-    "prepare": "git config core.hooksPath .githooks || true"
+    "prepare": "git config core.hooksPath .githooks || true",
+    "prepack": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- `main-ci.yml`'s release job runs `npm run build` before `npx semantic-release`, so `scripts/build.js` bakes `package.json`'s version (still `0.0.0-development` at that point) into the bundle banners.
- `npm publish` runs the `prepack` lifecycle script right before packing, which happens after semantic-release has already written the real release version — so adding `prepack: npm run build` re-runs the build at that point and produces a correct banner in the published tarball.
- This mirrors the existing pattern already in place in `chartjs-chart-sankey`, whose published bundle correctly shows its release version for this exact reason.

## Verification
- `npm run build`, `npm run lint`, `npm test`, `npm run test:coverage`, `npm run typecheck`, `npm run docs`, `npm run test:chartjs` all pass.
- Deleted `dist/` entirely and ran `npm pack`: the tarball's `prepack` step regenerated the full `dist/` output, proving `prepack` actually fires build during packing.
- Temporarily set `version` to `9.9.9`, ran `npm pack`, and confirmed the tarball's `dist/color.esm.js` banner read `@kurkle/color v9.9.9`. Version was reverted afterward; not committed.
- Could not verify the banner fix on the live npm registry — that only happens after merge and the next real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)